### PR TITLE
Signature infering as a new command in swam cli

### DIFF
--- a/cli/src/swam/cli/Main.scala
+++ b/cli/src/swam/cli/Main.scala
@@ -356,7 +356,7 @@ object Main extends CommandIOApp(name = "swam-cli", header = "Swam from the comm
                           }
                           val resultParams = mapping.mkString(",")
                           if (resultParams == "") {
-                            println("void")
+                            println("")
                           }
                           println(resultParams)
                         }

--- a/cli/src/swam/cli/Main.scala
+++ b/cli/src/swam/cli/Main.scala
@@ -342,7 +342,7 @@ object Main extends CommandIOApp(name = "swam-cli", header = "Swam from the comm
                             case FunctionNames(names) =>
                               
                               val mapList = names.values
-                              val check = mapList.exists(j => {j == func_name})
+                              val check = mapList.exists(j => j == func_name)
                               if(!check){
                                 System.err.println("Function name does not exists.")
                                 sys.exit(1)
@@ -354,8 +354,8 @@ object Main extends CommandIOApp(name = "swam-cli", header = "Swam from the comm
                         functionName match {
                           case Some(x) => {
                             if(x == func_name){
-                              val mapping = tpe.params.map(y => {
-                                y match {
+                              val mapping = tpe.params.map({
+                                _ match {
                                   case ValType.I32 => "Int32"
                                   case ValType.I64 => "Int64"
                                   case ValType.F32 => "Float32"

--- a/cli/src/swam/cli/Main.scala
+++ b/cli/src/swam/cli/Main.scala
@@ -340,6 +340,13 @@ object Main extends CommandIOApp(name = "swam-cli", header = "Swam from the comm
                           val functionName =
                           compiled.names.flatMap(_.subsections.collectFirstSome {
                             case FunctionNames(names) =>
+                              
+                              val mapList = names.values
+                              val check = mapList.exists(j => {j == func_name})
+                              if(!check){
+                                System.err.println("Function name does not exists.")
+                                sys.exit(1)
+                              }
                               names.get(typeIndex)
                             case _ =>
                               None
@@ -347,18 +354,24 @@ object Main extends CommandIOApp(name = "swam-cli", header = "Swam from the comm
                         functionName match {
                           case Some(x) => {
                             if(x == func_name){
-                              println(s"This is function name : $func_name")
-                              println(s"This is param names : ${tpe.params}")
+                              val mapping = tpe.params.map(y => {
+                                y match {
+                                  case ValType.I32 => "Int32"
+                                  case ValType.I64 => "Int64"
+                                  case ValType.F32 => "Float32"
+                                  case ValType.F64 => "Float64"
+                                }
+                              })
+                              val resultParams = mapping.mkString(",")
+                              if(resultParams == ""){
+                                println("void")
+                              } 
+                              println(resultParams)
                             }
                           } 
-                          case None => {
-                            println(s"The function name does not exists.")
-                          }
-                        }
-                        
+                          case _ => None
+                        }  
                     })
-                _ <- IO(Infer)
-                //_ <- IO(println(module))
               } yield ExitCode.Success
             case Compile(file, out, debug) =>
               for {

--- a/cli/src/swam/cli/options.scala
+++ b/cli/src/swam/cli/options.scala
@@ -71,3 +71,10 @@ case class WasmCov(file: Path,
                    filter: Boolean,
                    wasmArgTypes: List[String])
     extends Options
+
+case class Infer(file: Path,
+                 wat: Boolean,
+                 wasi: Boolean,  
+                 functionName:String
+                )extends Options
+

--- a/runtime/src/swam/runtime/Module.scala
+++ b/runtime/src/swam/runtime/Module.scala
@@ -45,12 +45,12 @@ class Module[F[_]] private[runtime] (
     private[runtime] val tables: Vector[TableType],
     private[runtime] val memories: Vector[MemType],
     private[runtime] val start: Option[Int],
-    private[runtime] val functions: Vector[CompiledFunction[F]],
+    val functions: Vector[CompiledFunction[F]],
     private[runtime] val elems: Vector[CompiledElem[F]],
     private[runtime] val data: Vector[CompiledData[F]])(implicit F: MonadError[F, Throwable]) {
   self =>
 
-  private[runtime] lazy val names = {
+    lazy val names = {
     val sec = customs.collectFirst {
       case Custom("name", payload) => payload
     }

--- a/runtime/src/swam/runtime/internals/compiler/CompiledFunction.scala
+++ b/runtime/src/swam/runtime/internals/compiler/CompiledFunction.scala
@@ -23,7 +23,7 @@ import cfg._
 import cats.effect.IO
 import swam.runtime.internals.interpreter.AsmInst
 
-private[runtime] case class CompiledFunction[F[_]](idx: Int,
+case class CompiledFunction[F[_]](idx: Int,
                                                    tpe: FuncType,
                                                    locals: Vector[ValType],
                                                    code: Array[AsmInst[F]])


### PR DESCRIPTION
Creating a pull request from Tareq one.

Signature inferring prints the value of the parameter of the functions name given by the command.
   sudo mill cli.run infer --wasi code_analysis/test/resources/coverage-test/formal_data/Deconvolution-1D.wasm _fft

  This is function name: _fft
  This is param names: Vector(I32, I32, I32, I32)